### PR TITLE
workflows: Build site from `main` branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - devel
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
This rebuilds the site from the main branch.

The `gh-pages` branch can then be selected for [publishing](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).

As is, the current hugo `baseURL` ([here](https://github.com/wepala/weos-documentation/blob/main/config/gh-pages/config.toml)) should work, but may be necessary to change in the future.